### PR TITLE
Odświeżenie regulaminu w kwestii VC, usunięcie botów muzycznych

### DIFF
--- a/data/faq/007_sekcja-organizacyjna/embeds/01/description.md
+++ b/data/faq/007_sekcja-organizacyjna/embeds/01/description.md
@@ -6,7 +6,6 @@ Jeśli chcesz pociągnąć jakiś temat dłużej (tak, by nie był jednorazową 
 - Double Counter - weryfikacja użytkowników
 - Carl-bot - nadawanie ról zgodnie z reakcjami na <#909039228904689675> oraz w zabawach, dziennik zdarzeń
 - MEE6 - wiadomości powitalne
-- aiode - odtwarzanie muzyki na kanałach głosowych
 - YAGPDB.xyz - śledzenie poziomu doświadczenia użytkowników, własne komendy serwerowe (listę komend można poznać, wpisując !cc na kanale <#909046513085321237>)
 - DISBOARD - wyświetlanie zaproszenia na serwer na publicznej liście disboard.org
 - Tatsu - zabawy, ekonomia

--- a/data/faq/014_organizational-section/embeds/01/description.md
+++ b/data/faq/014_organizational-section/embeds/01/description.md
@@ -6,7 +6,6 @@ If you want to discuss a longer topic (so that it is not a one-off conversation)
 - Double Counter - account verification
 - Carl-bot - reaction roles on <#909039228904689675> and in some server games, logging
 - MEE6 - welcome messages
-- aiode - playing music on voice channels
 - YAGPDB.xyz - leveling system, custom command (which can be listed by texting !cc on <#909046513085321237>)
 - DISBOARD - keeping an invite to this server on the disboard.org list
 - Tatsu - fun, economy

--- a/data/info/002_kanaly/embeds/06_rozmowy/description.md
+++ b/data/info/002_kanaly/embeds/06_rozmowy/description.md
@@ -1,6 +1,5 @@
-Rozmowy głosowe, rozmowy tekstowe z uczestnikami rozmów głosowych oraz ogłoszenia twórców wideo.
-- Komentowanie streamów, puszczanej muzyki i rozmów na kanałach głosowych: <#909046594421293076>
+Rozmowy głosowe, umawianie się na nie oraz ogłoszenia twórców wideo.
+- Umawianie się na aktywność głosową lub wspólne granie, komentowanie rozmów na kanałach głosowych: <#909046594421293076>
 - Ogłoszenia o reksiowych filmach i streamach: ⁠<#1267124282656428173>
-- Rozmowy głosowe w mniejszym gronie: <#909046821668675625>
-- Rozmowy głosowe w większym gronie: <#909046844053671966>
+- Rozmowy głosowe: <#909046821668675625>, <#909046844053671966>
 - Zorganizowane wystąpienia głosowe: <#1165597991168655421>

--- a/data/info/003_watki/embeds/01/description.md
+++ b/data/info/003_watki/embeds/01/description.md
@@ -1,4 +1,4 @@
-<#924724434697351238> - dzielenie się zdjęciami, skanami i opisami posiadanych gier AM.
+<#924724434697351238> - dzielenie się zdjęciami, skanami i opisami posiadanych gier AM. 
 <#1178965171587272724> - rozmowy o grach Aidem Media spoza serii "Przygody Reksia".
 <#909056082897436732> - rozmowy o serii gier "Wiedźmin". 
 <#945225687617388544> - twórczość muzyczna (plus polecajki).

--- a/data/info/003_watki/embeds/01/description.md
+++ b/data/info/003_watki/embeds/01/description.md
@@ -1,15 +1,14 @@
-<#913174618997665882> - obsługa botów muzycznych. 
-<#924724434697351238> - dzielenie się zdjęciami, skanami i opisami posiadanych gier AM. 
+<#924724434697351238> - dzielenie się zdjęciami, skanami i opisami posiadanych gier AM.
 <#1178965171587272724> - rozmowy o grach Aidem Media spoza serii "Przygody Reksia".
-<#909056082897436732> - rozmowy o serii gier "Wiedźmin". 
+<#909056082897436732> - rozmowy o serii gier "Wiedźmin".
 <#945225687617388544> - twórczość muzyczna (plus polecajki).
-<#987630870045270016> - generowanie tekstów, obrazów itp. z użyciem sztucznej inteligencji. 
-<#940904445343060028> - memy związane z fandomem i jego członkami, ale nie bezpośrednio z Przygodami Reksia. 
-<#924590672038723594> - wstawianie past i fragmentów z Nonsensopedii. 
-<#941708984421847040> - żenujące memy.  
-<#909192094055292968> - postowanie selfie. 
-<#909133916219252756> - rozmowy o zmyślonych związkach, czyli "shipach". 
-<#921110683653931069> - rozmowy o japońskich animacjach. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi). 
+<#987630870045270016> - generowanie tekstów, obrazów itp. z użyciem sztucznej inteligencji.
+<#940904445343060028> - memy związane z fandomem i jego członkami, ale nie bezpośrednio z Przygodami Reksia.
+<#924590672038723594> - wstawianie past i fragmentów z Nonsensopedii.
+<#941708984421847040> - żenujące memy.
+<#909192094055292968> - postowanie selfie.
+<#909133916219252756> - rozmowy o zmyślonych związkach, czyli "shipach".
+<#921110683653931069> - rozmowy o japońskich animacjach. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).
 <#1094306163283206215> - rozmowy o zjawiskach paranormalnych, ezoterycznych i magicznych, a także pseudonauce, paranauce i protonauce. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).
 ||<#1004866021108220005> - żarty, których nie przystoi postować nigdzie indziej, ale mieszczące się jeszcze w granicach regulaminu. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).||
 <#1233693523811893349> - wstawianie i ocenianie cytatów w formie dialogów oraz wiadomości z innych reksiowych platform/serwerów (obowiązuje regulamin <#1230099437423038535>).

--- a/data/info/003_watki/embeds/01/description.md
+++ b/data/info/003_watki/embeds/01/description.md
@@ -1,14 +1,14 @@
 <#924724434697351238> - dzielenie się zdjęciami, skanami i opisami posiadanych gier AM.
 <#1178965171587272724> - rozmowy o grach Aidem Media spoza serii "Przygody Reksia".
-<#909056082897436732> - rozmowy o serii gier "Wiedźmin".
+<#909056082897436732> - rozmowy o serii gier "Wiedźmin". 
 <#945225687617388544> - twórczość muzyczna (plus polecajki).
-<#987630870045270016> - generowanie tekstów, obrazów itp. z użyciem sztucznej inteligencji.
-<#940904445343060028> - memy związane z fandomem i jego członkami, ale nie bezpośrednio z Przygodami Reksia.
-<#924590672038723594> - wstawianie past i fragmentów z Nonsensopedii.
-<#941708984421847040> - żenujące memy.
-<#909192094055292968> - postowanie selfie.
-<#909133916219252756> - rozmowy o zmyślonych związkach, czyli "shipach".
-<#921110683653931069> - rozmowy o japońskich animacjach. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).
+<#987630870045270016> - generowanie tekstów, obrazów itp. z użyciem sztucznej inteligencji. 
+<#940904445343060028> - memy związane z fandomem i jego członkami, ale nie bezpośrednio z Przygodami Reksia. 
+<#924590672038723594> - wstawianie past i fragmentów z Nonsensopedii. 
+<#941708984421847040> - żenujące memy.  
+<#909192094055292968> - postowanie selfie. 
+<#909133916219252756> - rozmowy o zmyślonych związkach, czyli "shipach". 
+<#921110683653931069> - rozmowy o japońskich animacjach. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi). 
 <#1094306163283206215> - rozmowy o zjawiskach paranormalnych, ezoterycznych i magicznych, a także pseudonauce, paranauce i protonauce. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).
 ||<#1004866021108220005> - żarty, których nie przystoi postować nigdzie indziej, ale mieszczące się jeszcze w granicach regulaminu. Wymaga dostępu do <#909046538091778048> (jajo śmierdzi).||
 <#1233693523811893349> - wstawianie i ocenianie cytatów w formie dialogów oraz wiadomości z innych reksiowych platform/serwerów (obowiązuje regulamin <#1230099437423038535>).

--- a/data/info/004_role/embeds/01_ogolne/description.md
+++ b/data/info/004_role/embeds/01_ogolne/description.md
@@ -3,7 +3,7 @@
 <@&909364493405020180> - tymczasowy moderator serwera z ograniczonymi uprawnieniami
 <@&911539477921562674> - były członek kadry serwerowej, zachowujący część swoich dawnych uprawnień
 <@&940690420327923743>  - członek kolegialnego organu doradczego ze składem ustalanym w drodze demokratycznego głosowania, mający dostęp do specjalnych kanałów, na których prowadzone są obrady w sprawach ważnych dla organizacji serwera
-<@&1173366165121286286> - radny uzyskujący najwyższe poparcie, w jego kompetencjach leży zarządzanie Radą.
+<@&1173366165121286286> - radny uzyskujący najwyższe poparcie, w jego kompetencjach leży zarządzanie Radą. 
 <@&972961071444922378> - niepolskojęzyczny członek Rady Serwera, zarządca kanałów obcojęzycznych (<#909041188810661898> i <#1173378559037943958>), może pisać na <#1267124282656428173>
 <@&1072092954107326514> - zasłużony były członek Rady Serwera
 <@&833793553032413266> - osoba, która łoży na utrzymanie serwera, odznaczona WYJĄTKOWYM kolorkiem i mająca dostęp do kanału Rady Serwera

--- a/data/info/004_role/embeds/01_ogolne/description.md
+++ b/data/info/004_role/embeds/01_ogolne/description.md
@@ -3,14 +3,14 @@
 <@&909364493405020180> - tymczasowy moderator serwera z ograniczonymi uprawnieniami
 <@&911539477921562674> - były członek kadry serwerowej, zachowujący część swoich dawnych uprawnień
 <@&940690420327923743>  - członek kolegialnego organu doradczego ze składem ustalanym w drodze demokratycznego głosowania, mający dostęp do specjalnych kanałów, na których prowadzone są obrady w sprawach ważnych dla organizacji serwera
-<@&1173366165121286286> - radny uzyskujący najwyższe poparcie, w jego kompetencjach leży zarządzanie Radą. 
+<@&1173366165121286286> - radny uzyskujący najwyższe poparcie, w jego kompetencjach leży zarządzanie Radą.
 <@&972961071444922378> - niepolskojęzyczny członek Rady Serwera, zarządca kanałów obcojęzycznych (<#909041188810661898> i <#1173378559037943958>), może pisać na <#1267124282656428173>
 <@&1072092954107326514> - zasłużony były członek Rady Serwera
 <@&833793553032413266> - osoba, która łoży na utrzymanie serwera, odznaczona WYJĄTKOWYM kolorkiem i mająca dostęp do kanału Rady Serwera
 <@&909049889055445002> - zarządca <#909046389227536426>. Rola jest wyróżnieniem dla najaktywniejszych użytkowników tego kanału. Pozwala również na zarządzanie <#1267124105308536862>
 <@&909049864208392192> - zarządca <#909046426535862282>. Rola jest wyróżnieniem dla najaktywniejszych użytkowników tego kanału
 <@&1274834829606649896> - zarządca <#909046481795825685>. Rola jest wyróżnieniem dla najaktywniejszych użytkowników tego kanału
-<@&909077054459346945> - zarządca <#909046594421293076>. Rola jest wyróżnieniem dla najaktywniejszych użytkowników tego kanału. Pozwala również na zarządzanie kanałami głosowymi oraz botami muzycznymi
+<@&909077054459346945> - zarządca <#909046594421293076>. Rola jest wyróżnieniem dla najaktywniejszych użytkowników tego kanału. Pozwala również na zarządzanie kanałami głosowymi
 <@&977599336957489172> - zarządca wydarzeń, może pisać na <#1267124282656428173>
 <@&909039818728673360> - użytkownik pozbawiony możliwości zamieszczania wiadomości poza wyznaczonym dla niego kanałem ⁠<#914203503218548757> (lochy)
 <@&914203758072852501> - użytkownik pozbawiony możliwości zamieszczania wiadomości również na kanale ⁠lochy [Rola dla wybitnych]

--- a/data/info/008_channels/embeds/06_calls/description.md
+++ b/data/info/008_channels/embeds/06_calls/description.md
@@ -1,6 +1,5 @@
-Voice channels, text channels for conversations with the users of the voice channels and announcements from video content creators.
-- Commenting on streams, playing music and conversations on voice chats: <#909046594421293076>
+Voice channels, arranging voice activities/ gaming sessions and announcements from video content creators.
+- Arranging voice activities and gaming sessions, commenting on conversations on voice chats: <#909046594421293076>
 - Announcements regarding Reksio-related streams and video premieres: ⁠<#1267124282656428173>
-- Smaller talks: <#909046821668675625>
-- Bigger talks: <#909046844053671966>
+- Voice activities: <#909046821668675625>, <#909046844053671966>
 - Organized speeches: <#1165597991168655421>

--- a/data/info/008_channels/embeds/06_calls/description.md
+++ b/data/info/008_channels/embeds/06_calls/description.md
@@ -1,4 +1,4 @@
-Voice channels, arranging voice activities/ gaming sessions and announcements from video content creators.
+Voice channels, arranging voice activities and announcements from video content creators.
 - Arranging voice activities and gaming sessions, commenting on conversations on voice chats: <#909046594421293076>
 - Announcements regarding Reksio-related streams and video premieres: ⁠<#1267124282656428173>
 - Voice activities: <#909046821668675625>, <#909046844053671966>

--- a/data/info/009_threads/embeds/01/description.md
+++ b/data/info/009_threads/embeds/01/description.md
@@ -1,4 +1,3 @@
-<#913174618997665882> - music bots commands.
 <#924724434697351238> - sharing photos, scans and descriptions of your AM games.
 <#1178965171587272724> - conversations about Aidem Media games aside from "The Adventures of Reksio" series.
 <#909056082897436732> - conversations about "The Witcher" game series. 

--- a/data/info/010_roles/embeds/01_general/description.md
+++ b/data/info/010_roles/embeds/01_general/description.md
@@ -10,7 +10,7 @@
 <@&909049889055445002> - manages <#909046389227536426>. The role is an award for the most active users of this channel. Also, manages <#1267124105308536862>
 <@&909049864208392192> - manages <#909046426535862282>. This role is an award for the most active users of this channel
 <@&1274834829606649896> - manages <#909046481795825685>. The role is an award for the most active users of this channel
-<@&909077054459346945> - manages <#909046594421293076>. This role is an award for the most active users of this channel. Also, manages voice channels and music bots
+<@&909077054459346945> - manages <#909046594421293076>. This role is an award for the most active users of this channel. Also, manages voice channels
 <@&977599336957489172> - manages events and can write on <#1267124282656428173>
 <@&909039818728673360> - user who lost access to writing outside of <#914203503218548757>
 <@&914203758072852501> - user who lost access to writing in <#914203503218548757> (lochy) as well

--- a/data/rules/002_regulamin/content.md
+++ b/data/rules/002_regulamin/content.md
@@ -1,1 +1,2 @@
 # :flag_pl: Regulamin serwera Reksio Discord
+:warning: Regulamin obowiązuje zarówno na kanałach tekstowych, jak i głosowych!

--- a/data/rules/002_regulamin/embeds/01/description.md
+++ b/data/rules/002_regulamin/embeds/01/description.md
@@ -6,7 +6,7 @@
 
 4. Obowiązuje zakaz treści NSFW i obraźliwych. Obejmuje to nagość, seks, dotkliwą przemoc i inne poważnie niepokojące treści. Nie akceptujemy również oszustw, wyłudzania danych i celowego wprowadzania w błąd innych użytkowników.
 
-5. Dyskutowanie kontrowersyjnych tematów, zwłaszcza politycznych, a także wstawianie treści powiązanych z nimi jest dozwolone wyłącznie na kanale ⁠⁠<#909046538091778048>. Dostęp do niego uzyskuje się, wybierając odpowiednią rolę w <#909039228904689675>.
+5. Dyskutowanie kontrowersyjnych tematów, zwłaszcza politycznych, a także wstawianie treści powiązanych z nimi jest dozwolone wyłącznie na kanale ⁠⁠<#909046538091778048>. Dostęp do niego uzyskuje się, wybierając odpowiednią rolę w <#909039228904689675>. Dyskusje na kanałach głosowych mogą dotyczyć kontrowersji, o ile odpowiada to wszystkim rozmówcom.
 
 6. Spamowanie wiadomościami jest dozwolone wyłącznie na kanale <#909046498166186036> (jednak z poszanowaniem przypiętych tam zasad), zaś komendami do obsługi botów na <#909046513085321237>.
 

--- a/data/rules/002_regulamin/embeds/01/description.md
+++ b/data/rules/002_regulamin/embeds/01/description.md
@@ -1,13 +1,13 @@
 1. Główna tematyka tego serwera to Przygody Reksia, ale inne tematy również są na nim mile widziane.
 
-2. Do innych odnosimy się z szacunkiem. Wyzywanie innych użytkowników jest surowo zakazane! Niedozwolone jest również prowokowanie innych do kłótni i nadużywanie pingów.
+2. Do innych odnosimy się z szacunkiem. Wyzywanie innych użytkowników jest surowo zakazane! Niedozwolone jest również prowokowanie innych do kłótni, nadużywanie pingów czy uporczywe przeszkadzanie innym w rozmowach głosowych.
 
 3. Przekleństwa są dozwolone, ale doradzamy umiar. Najlepiej je cenzurować przy pomocy ||spoilerów|| lub zastępować część liter innymi znakami.
 
-4. Obowiązuje zakaz treści NSFW i obraźliwych. Obejmuje to wiadomości tekstowe, obrazy i linki zawierające nagość, seks, dotkliwą przemoc i inne poważnie niepokojące treści. Nie akceptujemy również oszustw, wyłudzania danych i celowego wprowadzania w błąd innych użytkowników.
+4. Obowiązuje zakaz treści NSFW i obraźliwych. Obejmuje to nagość, seks, dotkliwą przemoc i inne poważnie niepokojące treści. Nie akceptujemy również oszustw, wyłudzania danych i celowego wprowadzania w błąd innych użytkowników.
 
 5. Dyskutowanie kontrowersyjnych tematów, zwłaszcza politycznych, a także wstawianie treści powiązanych z nimi jest dozwolone wyłącznie na kanale ⁠⁠<#909046538091778048>. Dostęp do niego uzyskuje się, wybierając odpowiednią rolę w <#909039228904689675>.
 
-6. Spamowanie wiadomościami jest dozwolone wyłącznie na kanale <#909046498166186036> (jednak z poszanowaniem przypiętych tam zasad), zaś komendami do obsługi botów na <#909046513085321237>, a w przypadku botów muzycznych na <#913174618997665882> i kanałach głosowych.
+6. Spamowanie wiadomościami jest dozwolone wyłącznie na kanale <#909046498166186036> (jednak z poszanowaniem przypiętych tam zasad), zaś komendami do obsługi botów na <#909046513085321237>.
 
 7. Rozmawiamy wyłącznie na odpowiednich kanałach. Tak zwane off-topowanie nie jest zbyt uprzejme! Poza komendami związanymi z hazardem, zarezerwowanym dla <#909046513085321237> i komendami muzycznymi, można korzystać z botów na wszystkich kanałach, ale w umiarkowanych ilościach i w kontekście prowadzonej rozmowy.

--- a/data/rules/004_regulamin-3/embeds/01/description.md
+++ b/data/rules/004_regulamin-3/embeds/01/description.md
@@ -6,4 +6,4 @@
 
 18. Propozycje zmian na serwerze proszę kierować na <#909039074059370527> lub na PW do przedstawicieli administracji lub <@&940690420327923743>. Jeśli chcesz zaangażować się bardziej w budowę serwera, możesz wystartować w wyborach do wspomnianej rady. Działa ona na specjalnych kanałach, do których dostęp, oprócz członków rady, mają również osoby boostujące serwer.
 
-19. Niektóre kanały posiadają (w przypiętych wiadomościach) dodatkowy regulamin, do którego również należy się stosować. Kanały te są wymienione na <#1180897754327826503>. Regulamin z <#909046594421293076> obejmuje również kanały głosowe.
+19. Niektóre kanały posiadają (w przypiętych wiadomościach) dodatkowy regulamin, do którego również należy się stosować. Kanały te są wymienione na <#1180897754327826503>.

--- a/data/rules/004_regulamin-3/embeds/01/description.md
+++ b/data/rules/004_regulamin-3/embeds/01/description.md
@@ -2,7 +2,7 @@
 
 16. Ten serwer ma pokojowo współistnieć i współpracować z innymi serwerami i serwisami związanymi z Reksiem. Wszyscy fani Dzielnego Psa i Kreta Kretesa są tu mile widziani niezależnie od poglądów społeczno-politycznych. Z tego powodu serwer zachowuje neutralność światopoglądową, aby użytkownicy mogli się dzielić swoimi opiniami bez przeszkód.
 
-17. Jeśli widzisz coś niezgodnego z zasadami lub sprawiającego, że nie czujesz się bezpiecznie (pomijając rozmowy na kontrowersyjne tematy na <#909046538091778048>), daj znać administracji. Chcemy, by ten serwer był przyjaznym miejscem!
+17. Jeśli widzisz coś niezgodnego z zasadami lub sprawiającego, że nie czujesz się bezpiecznie, daj znać administracji. Chcemy, by ten serwer był przyjaznym miejscem! Wyjątek stanowią rozmowy na kontrowersyjne tematy odbywające się na kanale <#909046538091778048> oraz (za zgodą wszystkich rozmówców) na kanałach głosowych.
 
 18. Propozycje zmian na serwerze proszę kierować na <#909039074059370527> lub na PW do przedstawicieli administracji lub <@&940690420327923743>. Jeśli chcesz zaangażować się bardziej w budowę serwera, możesz wystartować w wyborach do wspomnianej rady. Działa ona na specjalnych kanałach, do których dostęp, oprócz członków rady, mają również osoby boostujące serwer.
 

--- a/data/rules/005_taryfikator/embeds/01/description.md
+++ b/data/rules/005_taryfikator/embeds/01/description.md
@@ -10,3 +10,4 @@
 10. W wyjątkowych przypadkach możliwe jest przyznanie wyciszenia do odwołania, jeśli użytkownik był karany bardzo często lub bardzo surowo, a mimo to nadal sprawia problemy, łamiąc regulamin. Muty te mogą być poprzedzone czasowym banem.
 11. Pierwsze przewinienia karane możliwie łagodnie.
 12. Częste wchodzenie i wychodzenie z serwera lub zbyt częste zmienianie głównego konta na serwerze (nawet mimo regulaminowego zgłoszenia tego zamiaru administracji) skutkować może ostrzeżeniem, odroczeniem ręcznej weryfikacji (tylko dla nowych kont), a w skrajnych przypadkach - banem.
+13. Jeśli brak innych dowodów na szkodliwą działalność użytkownika na kanale głosowym, kadra rozpatruje sprawę na podstawie zeznań członka kadry lub co najmniej 2 użytkowników.

--- a/data/rules/006_netykieta/embeds/01/description.md
+++ b/data/rules/006_netykieta/embeds/01/description.md
@@ -5,4 +5,4 @@
 5. Problemy techniczne występujące na serwerze można zgłaszać na <#909039074059370527>.
 6. Nie wypominamy sobie błędów dla samego ich wypominania. Lepiej zachować spokój niż uporczywie rozgrzebywać stare i zamknięte niekomfortowe sprawy, problemy, dramy. Ciągnięcie polemiki w nieskończoność prowadzi do ostrych, zbędnych kłótni przeszkadzających innym użytkownikom - zwłaszcza, gdy robi się to na kanałach ogólnych z użyciem rynsztokowego słownictwa. Dopuszcza się poruszanie takich kwestii na <#909046538091778048> przy zachowaniu odpowiedniego poziomu kultury osobistej. <:happy:909045208505794590>
 7. Po angielsku można pisać na wszystkich kanałach. Na dłuższe rozmowy w językach innych niż polski zapraszamy na ⁠<#909041188810661898> i <#1173378559037943958>.
-8. Podczas rozmów głosowych należy wyciszyć dźwięki tła, jeśli to możliwe. Należy też unikać zbyt głośnych dźwięków ogółem.
+8. Podczas rozmów głosowych należy wyciszyć dźwięki tła, jeśli to możliwe. Należy też unikać zbyt głośnych dźwięków ogółem. Nieuprzejme jest również wzajemne przekrzykiwanie się czy narzucanie pozostałym rozmówcom tematu, którym nie są zainteresowani.

--- a/data/rules/006_netykieta/embeds/01/description.md
+++ b/data/rules/006_netykieta/embeds/01/description.md
@@ -5,3 +5,4 @@
 5. Problemy techniczne występujące na serwerze można zgłaszać na <#909039074059370527>.
 6. Nie wypominamy sobie błędów dla samego ich wypominania. Lepiej zachować spokój niż uporczywie rozgrzebywać stare i zamknięte niekomfortowe sprawy, problemy, dramy. Ciągnięcie polemiki w nieskończoność prowadzi do ostrych, zbędnych kłótni przeszkadzających innym użytkownikom - zwłaszcza, gdy robi się to na kanałach ogólnych z użyciem rynsztokowego słownictwa. Dopuszcza się poruszanie takich kwestii na <#909046538091778048> przy zachowaniu odpowiedniego poziomu kultury osobistej. <:happy:909045208505794590>
 7. Po angielsku można pisać na wszystkich kanałach. Na dłuższe rozmowy w językach innych niż polski zapraszamy na ⁠<#909041188810661898> i <#1173378559037943958>.
+8. Podczas rozmów głosowych należy wyciszyć dźwięki tła, jeśli to możliwe. Należy też unikać zbyt głośnych dźwięków ogółem.

--- a/data/rules/007_rules/content.md
+++ b/data/rules/007_rules/content.md
@@ -1,1 +1,2 @@
 # :flag_us: Reksio Discord rules
+:warning: The rules apply to both text and voice channels!

--- a/data/rules/007_rules/embeds/01/description.md
+++ b/data/rules/007_rules/embeds/01/description.md
@@ -6,7 +6,7 @@
 
 4. NSFW and offensive content is prohibited. This includes nudity, sex, severe violence, or other seriously disturbing content. We neither tolerate fraud nor phishing or intentional misinformation.
 
-5. Discussions over controversial topics, especially political ones, as well as related content are allowed only on the⁠ <#909046538091778048> channel. To access it, you need to choose the appropriate role on <#909039228904689675>.
+5. Discussions over controversial topics, especially political ones, as well as related content are allowed only on the⁠ <#909046538091778048> channel. To access it, you need to choose the appropriate role on <#909039228904689675>. Voice discussions can also touch upon controversial topics, but only if all disputants agree on it.
 
 6. Spamming with messages is allowed only on <#909046498166186036> (but respecting the rules pinned there), with bot commands on <#909046513085321237>.
 

--- a/data/rules/007_rules/embeds/01/description.md
+++ b/data/rules/007_rules/embeds/01/description.md
@@ -1,13 +1,13 @@
 1. The main theme of this server is Rex Adventures games, but other topics are also welcome.
 
-2. We treat others with respect. It is strictly forbidden to be rude to other users! It is also not allowed to abuse pings and to provoke other people to quarrels.
+2. We treat others with respect. It is strictly forbidden to be rude to other users! It is also not allowed to abuse pings, to provoke other people to quarrels, or to disrupt voice discussions.
 
 3. Swearing is allowed but we advise moderation. It is best to censor them with ||spoilers|| or replace some letters with other characters.
 
-4. NSFW and offensive content is prohibited. This includes text messages, images, and links that contain nudity, sex, severe violence, or other seriously disturbing content. We neither tolerate fraud nor phishing or intentional misinformation.
+4. NSFW and offensive content is prohibited. This includes nudity, sex, severe violence, or other seriously disturbing content. We neither tolerate fraud nor phishing or intentional misinformation.
 
 5. Discussions over controversial topics, especially political ones, as well as related content are allowed only on the⁠ <#909046538091778048> channel. To access it, you need to choose the appropriate role on <#909039228904689675>.
 
-6. Spamming with messages is allowed only on <#909046498166186036> (but respecting the rules pinned there), with bot commands on <#909046513085321237>, and with music bots commands on <#913174618997665882> and the voice channels.
+6. Spamming with messages is allowed only on <#909046498166186036> (but respecting the rules pinned there), with bot commands on <#909046513085321237>.
 
 7. We only talk on the appropriate channels. The off-topic is not very polite! Except for gambling commands reserved for <#909046513085321237> and for music commands, you can use bots on all channels, but in moderation and in the context of the conversation.

--- a/data/rules/009_rules-3/embeds/01/description.md
+++ b/data/rules/009_rules-3/embeds/01/description.md
@@ -6,4 +6,4 @@
 
 18. Suggestions for changes on the server should be sent on <#909039074059370527> or on priv to the members of administration or <@&940690420327923743> (Server Council). If you intend to engage further in creating the server, you can participate in the election for the Council. It operates on dedicated channels, which - apart from the Council members - may be seen by server boosters.
 
-19. Some channels have additional rules (in pinned messages) which ought to be respected too. Those channels are listed on <#1180897754327826503>. Rules from <#909046594421293076> apply to voice channels as well.
+19. Some channels have additional rules (in pinned messages) which ought to be respected too. Those channels are listed on <#1180897754327826503>.

--- a/data/rules/009_rules-3/embeds/01/description.md
+++ b/data/rules/009_rules-3/embeds/01/description.md
@@ -2,7 +2,7 @@
 
 16. This server is supposed to coexist peacefully and cooperate with other servers and services on the subject of Rex. All fans of the Brave Dog and Moles the Mole are welcome here regardless of their socio-political views. For this reason, the server maintains worldview neutrality so that users can share their opinions without any obstacles.
 
-17. If you see anything that is against the rules or makes you feel unsafe (excluding discussions on controversial topics on <#909046538091778048>), let the administration know. We want this server to be a friendly place!
+17. If you see anything that is against the rules or makes you feel unsafe, let the administration know. We want this server to be a friendly place! Don't forget discussions on controversial topics on voice channels (if agreed upon by all disputants) and on <#909046538091778048> are exceptions from this rule.
 
 18. Suggestions for changes on the server should be sent on <#909039074059370527> or on priv to the members of administration or <@&940690420327923743> (Server Council). If you intend to engage further in creating the server, you can participate in the election for the Council. It operates on dedicated channels, which - apart from the Council members - may be seen by server boosters.
 

--- a/data/rules/010_tariff/embeds/01/description.md
+++ b/data/rules/010_tariff/embeds/01/description.md
@@ -10,3 +10,4 @@
 10. In exceptional cases, it is possible to be muted until further notice, if the user has been punished very often or very severely, and still causes problems by breaking the server rules. These mutes may be preceded by a temporary ban.
 11. First offenses punishable as mildly as possible.
 12. Frequent entering and exiting the server or changing the main account on the server too often (even despite the statutory notification of this intention to administration) may result in a warning, manual verification being postponed (only for recently created accounts) or, in extreme cases, a ban.
+13. If there is no other evidence of harmful voice channel activity, the case is examined based upon the testimony of an administration member or at least 2 users.

--- a/data/rules/011_netiquette/embeds/01/description.md
+++ b/data/rules/011_netiquette/embeds/01/description.md
@@ -5,3 +5,4 @@
 5. Technical problems on the server can be reported to <#909039074059370527>.
 6. Do not bring up others' wrongdoings just for the sake of it. It's better to remain calm than persistently bring up old, closed and uncomfortable topics, problems and dramas. Prolonging arguments with no intention to end them leads to unnecessary quarrels that disturb the peace of other users, especially when you do it on general channels using vulgar language. Discussing such topics is only acceptable on ⁠⁠<#909046538091778048> on condition that you keep it civil. <:happy:909045208505794590>
 7. You can speak English anywhere on the server. But for longer conversations in English or other languages we recommend non-Polish channels: ⁠⁠⁠<#909041188810661898> and <#1173378559037943958>.
+8. When using voice channels, you should reduce background noise as much as possible. Watch out for too loud sounds in general!

--- a/data/rules/011_netiquette/embeds/01/description.md
+++ b/data/rules/011_netiquette/embeds/01/description.md
@@ -5,4 +5,4 @@
 5. Technical problems on the server can be reported to <#909039074059370527>.
 6. Do not bring up others' wrongdoings just for the sake of it. It's better to remain calm than persistently bring up old, closed and uncomfortable topics, problems and dramas. Prolonging arguments with no intention to end them leads to unnecessary quarrels that disturb the peace of other users, especially when you do it on general channels using vulgar language. Discussing such topics is only acceptable on ⁠⁠<#909046538091778048> on condition that you keep it civil. <:happy:909045208505794590>
 7. You can speak English anywhere on the server. But for longer conversations in English or other languages we recommend non-Polish channels: ⁠⁠⁠<#909041188810661898> and <#1173378559037943958>.
-8. When using voice channels, you should reduce background noise as much as possible. Watch out for too loud sounds in general!
+8. When using voice channels, you should reduce background noise as much as possible. Watch out for too loud sounds in general! Additionally, it is impolite to shout at each other or to force other interlocutors to discuss on a topic they are not interested in.


### PR DESCRIPTION
## Motywacja

- oddzielenie regulaminu kanałów głosowych od ogólnego powoduje więcej zamieszania niż pożytku
- brak jasnych wytycznych co do prowadzenia kontrowersyjnych rozmów na kanałach głosowych
- boty muzyczne nie są używane przez użytkowników (którzy preferują aktywności), a poza tym i tak mają problemy z działaniem
- w związku z brakiem potrzeby używania botów muzycznych, niepotrzebny staje się również wątek na komendy do nich
- zmieniła się rola kanału #szangri-la, a ograniczenie liczebności kanału głosowego straciło sens

## Wykonane zmiany

### #info
- Szambo-La zostało usunięte z listy stałych wątków
- z opisu roli DJ została usunięta wzmianka o zarządzaniu botami muzycznymi
- opis kanałów #szangri-la oraz #Egipt i #Ameryka został zaktualizowany

### #faq
- usunięty został opis bota muzycznego aiode

### #rules
- na górze regulaminu zostało dodane przypomnienie, że "⚠️ Regulamin obowiązuje zarówno na kanałach tekstowych, jak i głosowych"
- punkt 2. uzupełniono o przeszkadzanie w rozmowach głosowych
- z punktu 4. została usunięta potencjalnie myląca wzmianka o wiadomościach tekstowych
- punkt 5. obejmuje teraz również kanały głosowe (w związku z czym punkt 17. również)
- z punktu 6. została usunięta wzmianka o wątku Szambo-la
- z punktu 19. została usunięta informacja o dodatkowym regulaminie kanałów głosowych na #szangri-la

- do taryfikatora został dodany punkt odnośnie dowodów w sprawie zachowania na kanałach głosowych

- do netykiety został dopisany punkt o savoir-vivrze rozmów głosowych